### PR TITLE
Fix for graphene ui on debug mode

### DIFF
--- a/src/office/views.py
+++ b/src/office/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _
@@ -17,6 +18,9 @@ def check_jwt_decorator(func):
     """
 
     def wrap(request, *args, **kwargs):
+        if settings.DEBUG:
+            if request.user.is_authenticated():
+                return func(request, *args, **kwargs)
         try:
             auth_tuple = JSONWebTokenAuthentication().authenticate(request)
         except APIException as e:


### PR DESCRIPTION
would be used on debug mode. user can have access into graphene UI without JWT if authenticated