### PR TITLE
Docker: migrate from python:3.5 to alpine:3.8 baseimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,32 @@
-# python image using Debian Jessie
-FROM python:3.5
+FROM alpine:3.8
+
 ENV PYTHONUNBUFFERED 1
+
 COPY ./src /opt/office-manager
 COPY ./.env /opt/office-manager/.env
 COPY requirements.txt /opt/office-manager/
+
+RUN apk --update add \
+    gcc \
+    jpeg-dev \
+    libffi-dev \
+    libressl-dev \
+    make \
+    musl-dev \
+    postgresql-dev \
+    # Python 3.6.6 is used
+    python3 \
+    python3-dev \
+    zlib-dev \
+ && adduser --disabled-password --gecos '' office_user \
+ && cd /opt/office-manager \
+ && pip3 install --upgrade pip \
+ && pip3 install -r ./requirements.txt \
+ && apk del \
+    gcc \
+    make \
+    musl-dev \
+    python-dev \
+ && rm -rf /var/cache/apk/*
+
 WORKDIR /opt/office-manager
-RUN pip3 install pip
-RUN pip3 install -r ./requirements.txt
-RUN adduser --disabled-password --gecos '' office_user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
     depends_on:
       - "database"
       - "redis"
-    command: bash -c "python3 manage.py collectstatic --noinput &&
-                      python3 manage.py makemigrations &&
-                      python3 manage.py migrate &&
-                      python3 manage.py runserver 0.0.0.0:8000"
+    command: sh -c "python3 manage.py collectstatic --noinput &&
+                    python3 manage.py makemigrations &&
+                    python3 manage.py migrate &&
+                    python3 manage.py runserver 0.0.0.0:8000"
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
The result Docker image is six times smaller than the old one.